### PR TITLE
Doesn't try to process empty body from modular pages and throw error.

### DIFF
--- a/vendor/imangazaliev/didom/src/DiDom/Document.php
+++ b/vendor/imangazaliev/didom/src/DiDom/Document.php
@@ -52,7 +52,7 @@ class Document
 
         $this->preserveWhiteSpace(false);
 
-        if ($string !== null) {
+        if ($string !== null and $string !=="") {
             $this->load($string, $isFile, $type);
         }
     }


### PR DESCRIPTION
fixes trilbymedia/grav-plugin-image-captions#1