### PR TITLE
bugfix: Removes extra html and body tags from the page content

### DIFF
--- a/image-captions.php
+++ b/image-captions.php
@@ -122,9 +122,22 @@ class ImageCaptionsPlugin extends Plugin
                     $image->replace($figure);
                 }
             }
-            return $document->html();
+            return $this->cleanupTags($document->html());
         }
 
         return $content;
+    }
+
+    /**
+     * Removes html and body tags at the begining and end of the html source
+     *
+     * @param $html
+     * @return string
+     */
+    private static function cleanupTags($html)
+    {
+        $html = preg_replace('@^<html><body>\\n@', '', $html);
+        $html = preg_replace('@\\n</body></html>$@', '', $html);
+        return $html;
     }
 }


### PR DESCRIPTION
This plugin uses  `DiDom\Document::html` and this method adds `<html><body>\n` and `\n</body></html>`. This fix removes that.

I honnestly didn't take a look at a best solution with `DiDom`.

Fixes https://github.com/trilbymedia/grav-plugin-image-captions/issues/9